### PR TITLE
Add config as a parameter

### DIFF
--- a/src/streamlit_plotly_events/__init__.py
+++ b/src/streamlit_plotly_events/__init__.py
@@ -1,6 +1,6 @@
 import os
 import streamlit.components.v1 as components
-from json import loads
+from json import loads, dumps
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
@@ -51,6 +51,7 @@ def plotly_events(
     hover_event=False,
     override_height=450,
     override_width="100%",
+    config={},
     key=None,
 ):
     """Create a new instance of "plotly_events".
@@ -69,6 +70,8 @@ def plotly_events(
         Integer to override component height.  Defaults to 450 (px)
     override_width: string, default: '100%'
         String (or integer) to override width.  Defaults to 100% (whole width of iframe)
+    config: dictionary, default: {}
+        Plotly config dictionary. Defaults to {}
     key: str or None
         An optional key that uniquely identifies this component. If this is
         None, and the component's arguments are changed, the component will
@@ -98,6 +101,7 @@ def plotly_events(
         plot_obj=plot_fig.to_json(),
         override_height=override_height,
         override_width=override_width,
+        config=dumps(config),
         key=key,
         click_event=click_event,
         select_event=select_event,
@@ -121,7 +125,7 @@ if not _RELEASE:
     st.subheader("Plotly Line Chart")
     fig = px.line(x=[0, 1, 2, 3], y=[0, 1, 2, 3])
     plot_name_holder = st.empty()
-    clickedPoint = plotly_events(fig, key="line")
+    clickedPoint = plotly_events(fig, key="line", config={"displayModeBar": True})
     plot_name_holder.write(f"Clicked Point: {clickedPoint}")
 
     # Here we add columns to check auto-resize/etc

--- a/src/streamlit_plotly_events/frontend/src/StreamlitPlotlyEventsComponent.tsx
+++ b/src/streamlit_plotly_events/frontend/src/StreamlitPlotlyEventsComponent.tsx
@@ -10,6 +10,7 @@ class StreamlitPlotlyEventsComponent extends StreamlitComponentBase {
   public render = (): ReactNode => {
     // Pull Plotly object from args and parse
     const plot_obj = JSON.parse(this.props.args["plot_obj"]);
+    const config = JSON.parse(this.props.args["config"]);
     const override_height = this.props.args["override_height"];
     const override_width = this.props.args["override_width"];
 
@@ -23,7 +24,7 @@ class StreamlitPlotlyEventsComponent extends StreamlitComponentBase {
       <Plot
         data={plot_obj.data}
         layout={plot_obj.layout}
-        config={plot_obj.config}
+        config={config}
         frames={plot_obj.frames}
         onClick={click_event ? this.plotlyEventHandler : function(){}}
         onSelected={select_event ? this.plotlyEventHandler : function(){}}


### PR DESCRIPTION
There is currently no way to pass the plotly config through to the frontend as config does not exist as an attribute on the Plotly Figure, which is what the react component is currently expecting. 

This change adds a config dictionary as a parameter so it can be passed directly through to the frontend.

I also added some config to one of the test examples.
